### PR TITLE
change-md-component-use-text-insted-url

### DIFF
--- a/src/stories/components/markdown/markdown.stories.tsx
+++ b/src/stories/components/markdown/markdown.stories.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import MdViewerContainer from './md-view-container';
 
@@ -10,7 +9,29 @@ export default {
 
 const Template: ComponentStory<typeof MdViewerContainer> = (args) => <MdViewerContainer {...args} />;
 
+const markdownText = `### About Sustainable Ecosystem Scaling Core Unit
+Sustainable Ecosystem Scaling
+
+### What we do
+
+#### Mission  
+
+
+Sustainably grow the Maker Protocol's moats by systematically removing barriers between the decentralized workforce, capital, and work.      
+
+### Vision
+
+To support a decentralized, effective, and scalable economy on top of the Maker Protocol that continues to push forward its growth in a sustainable manner.
+
+This decentralized, effective, and scalable economy:
+Has the best and most successful onboarding experience for new participants, with the highest retention rate in the industry.
+Allows everyone to find the capital they need to work on the best projects which (1) optimally drive protocol growth and (2) are most fulfilling for its participants.
+Has resilient safety mechanisms in place that prevent protocol failure while leaving ample space for rapid innovation and experimentation.
+
+
+![The San Juan Mountains are beautiful!](https://ownsnap.com/wp-content/uploads/2021/10/dao1-1170x658-1.jpg "San Juan Mountains")`;
+
 export const Default = Template.bind({});
 Default.args = {
-  url: 'https://raw.githubusercontent.com/mact200590/Proyectos/master/example.md',
+  markdown: markdownText
 };

--- a/src/stories/components/markdown/md-view-container.tsx
+++ b/src/stories/components/markdown/md-view-container.tsx
@@ -1,39 +1,15 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { CircularProgress } from '@mui/material';
-
+import React, { useCallback, useState } from 'react';
 import { marked } from 'marked';
 
 import MdViewerPage, { MarkDownHeaders } from './md-view';
 import makerRender from './renderUtils';
 
 interface Props {
-  url: string;
+  markdown: string;
 }
 
-const MdViewerContainer = ({ url }: Props) => {
-  const [loading, setLoading] = useState<boolean>(false);
-  const [markdownText, setMarkdownText] = useState<string>('');
+const MdViewerContainer = ({ markdown }: Props) => {
   const [headersLevel, setHeadersLevel] = useState<MarkDownHeaders[]>([]);
-
-  useEffect(() => {
-    const fetchCreator = async() => {
-      try {
-        setLoading(true);
-        const response = await fetch(url);
-        if (!response.ok) {
-          console.log('firstError', response.status);
-        } else {
-          const parsed = await response.text();
-          setMarkdownText(marked.parse(parsed));
-        }
-        setLoading(false);
-      } catch (error) {
-        console.log('not-found');
-      }
-    };
-    fetchCreator();
-  }, []);
-
   const creatingIndexItems = useCallback(
     (level: number, htmlCleanedText: string, escapedText: string) => {
       const cleanedText = htmlCleanedText
@@ -53,16 +29,13 @@ const MdViewerContainer = ({ url }: Props) => {
     },
     [headersLevel],
   );
+  const parsed = marked.parse(markdown);
   marked.use({
     renderer: makerRender({ forEachHeading: creatingIndexItems }),
   });
-
-  if (loading) return <CircularProgress color="inherit" />;
-
   return (
     <MdViewerPage
-      markdownText={markdownText}
-      mdUrl={markdownText}
+      markdownText={parsed}
       headersLevel={headersLevel}
     />
   );

--- a/src/stories/components/markdown/md-view.tsx
+++ b/src/stories/components/markdown/md-view.tsx
@@ -12,7 +12,6 @@ export type MarkDownHeaders = {
 
 interface Props {
     markdownText: string;
-    mdUrl?: string;
     headersLevel: MarkDownHeaders[];
 }
 

--- a/src/stories/components/sidebar/sidebar.tsx
+++ b/src/stories/components/sidebar/sidebar.tsx
@@ -19,7 +19,6 @@ interface SidebarProps {
 export const Sidebar = (props: SidebarProps) => {
   const [stack, setStack] = useState<string[]>([]);
   const { hash } = useLocation();
-  console.log('pathname', hash);
 
   useEffect(() => {
     hash && setStack((hash.replace('#', '')).split('/').filter(Boolean));
@@ -75,8 +74,6 @@ const MenuItemsView = ({
   stack, setStack,
   beforeLevel = 0,
 }: MenuItemsViewProps) => {
-  const location = useLocation();
-  console.log('location', location);
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   const toggle = useCallback(() => {
   }, []);


### PR DESCRIPTION
# Ticket
[Trello-20-layout-cu-about](https://trello.com/c/JqoadMnP/20-layout-cu-about)

# Description
The "CU About" view will be presented once the user clicks on the "Core Unit -> About" option in 

 # Actions
 Change the md-view components to work with text instead of url 
