### PR TITLE
[SES-110] Reflect the filter and sorting in the inside pagination of cu about

### DIFF
--- a/src/stories/components/core-unit-summary/core-unit-summary.mvvm.ts
+++ b/src/stories/components/core-unit-summary/core-unit-summary.mvvm.ts
@@ -31,6 +31,20 @@ const CORE_UNITS_REQUEST = {
           linkedIn
           website
         }
+        budgetStatements {
+          month
+          budgetStatementFTEs {
+            month
+            ftes
+          }
+          budgetStatus,
+          budgetStatementWallet {
+            budgetStatementLineItem {
+              actual
+              month
+            }
+          }
+        }
       }
    }
 `

--- a/src/stories/components/cu-table-column-team-member/cu-table-column-team-member.stories.tsx
+++ b/src/stories/components/cu-table-column-team-member/cu-table-column-team-member.stories.tsx
@@ -4,7 +4,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import cuTableReducer, {
-  CuTableState,
+  CuTableState, sortNeutralState,
 } from '../../containers/cu-table/cu-table.slice';
 import { CuJobEnum } from '../../../core/enums/cu-job.enum';
 import { ContributorCommitmentDto } from '../../../core/models/dto/core-unit.dto';
@@ -18,6 +18,8 @@ const store = configureStore({
 const MockedState: CuTableState = {
   items: [],
   status: 'idle',
+  sortColumn: 0,
+  headersSort: sortNeutralState
 };
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/src/stories/components/custom-table/custom-table.tsx
+++ b/src/stories/components/custom-table/custom-table.tsx
@@ -1,26 +1,30 @@
 import React, { CSSProperties, useMemo } from 'react';
 import styled from '@emotion/styled';
 import { CustomTableHeader } from '../custom-table-header/custom-table-header';
-import { SortEnum } from '../../../core/enums/sort.enum';
 import { useThemeContext } from '../../../core/context/ThemeContext';
 import { CustomTableHeaderSkeleton } from './custom-table-header.skeleton';
+import { useSelector } from 'react-redux';
+import { RootState } from '../../../core/store/store';
+import { selectCuTableHeadersSort, setSort } from '../../containers/cu-table/cu-table.slice';
+import { useAppDispatch } from '../../../core/hooks/hooks';
 
 interface CustomTableProps {
   headers: string[];
   items?: (JSX.Element | string)[][];
   headersAlign?: ('flex-start' | 'center' | 'flex-end')[];
   headersStyles?: CSSProperties[];
-  headersSort?: SortEnum[];
-  sortFunction?: (index: number, previousSort: SortEnum) => void;
   loading?: boolean;
 }
 
 export const CustomTable = ({
-  headersSort = [],
   headersStyles = [],
   ...props
 }: CustomTableProps) => {
   const isLight = useThemeContext().themeMode === 'light';
+  const dispatch = useAppDispatch();
+
+  const headersSort = useSelector((state: RootState) => selectCuTableHeadersSort(state));
+  const handleSort = (index: number) => dispatch(setSort(index));
 
   const tableHead = useMemo(() => {
     if (props.loading) {
@@ -36,11 +40,7 @@ export const CustomTable = ({
                 justifyContent: props.headersAlign && props.headersAlign[i],
               }}
               onClick={() =>
-                headersSort &&
-                headersSort[i] &&
-                headersSort[i] !== SortEnum.Disabled &&
-                props.sortFunction &&
-                props.sortFunction(i, headersSort[i])
+                handleSort(i)
               }
             >
               <CustomTableHeader

--- a/src/stories/containers/cu-table/cu-table.slice.ts
+++ b/src/stories/containers/cu-table/cu-table.slice.ts
@@ -11,7 +11,7 @@ export interface CuTableState {
   headersSort: SortEnum[];
 }
 
-const sortNeutralState = [
+export const sortNeutralState = [
   SortEnum.Neutral,
   SortEnum.Neutral,
   SortEnum.Neutral,

--- a/src/stories/containers/cu-table/cu-table.slice.ts
+++ b/src/stories/containers/cu-table/cu-table.slice.ts
@@ -1,16 +1,33 @@
-import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RootState } from '../../../core/store/store';
 import { fetchCoreUnits } from './cu-table.api';
 import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
+import { SortEnum } from '../../../core/enums/sort.enum';
 
 export interface CuTableState {
-  items: CoreUnitDto[],
-  status: string,
+  items: CoreUnitDto[];
+  status: string;
+  sortColumn: number;
+  headersSort: SortEnum[];
 }
+
+const sortNeutralState = [
+  SortEnum.Neutral,
+  SortEnum.Neutral,
+  SortEnum.Neutral,
+  SortEnum.Neutral,
+];
 
 const initialState: CuTableState = {
   items: [],
   status: 'loading',
+  sortColumn: 0,
+  headersSort: [
+    SortEnum.Asc,
+    SortEnum.Neutral,
+    SortEnum.Neutral,
+    SortEnum.Neutral,
+  ],
 };
 
 export const loadCuTableItemsAsync = createAsyncThunk(
@@ -24,25 +41,48 @@ export const cuTableSlice = createSlice({
   name: 'cuTable',
   initialState,
   reducers: {
-    clearTable: (state) => {
+    clearTable: (state: CuTableState) => {
       state.items = [];
+    },
+    resetHeaderSorting: (state: CuTableState) => {
+      state.headersSort = sortNeutralState;
+    },
+    setSortColumn: (state: CuTableState, action: PayloadAction<number>) => {
+      state.sortColumn = action.payload;
+    },
+    setSort: (state: CuTableState, action: PayloadAction<number>) => {
+      if (state.headersSort[action.payload] === 3) {
+        state.headersSort = sortNeutralState;
+        state.sortColumn = -1;
+      } else {
+        const temp = [...sortNeutralState];
+        temp[action.payload] = state.headersSort[action.payload] + 1;
+        state.headersSort = temp;
+        state.sortColumn = action.payload;
+      }
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(loadCuTableItemsAsync.pending, (state) => {
-      state.status = 'loading';
-    }).addCase(loadCuTableItemsAsync.fulfilled, (state, action) => {
-      state.status = 'idle';
-      state.items = action.payload as [];
-    }).addCase(loadCuTableItemsAsync.rejected, (state) => {
-      state.status = 'idle';
-    });
-  }
+    builder
+      .addCase(loadCuTableItemsAsync.pending, (state) => {
+        state.status = 'loading';
+      })
+      .addCase(loadCuTableItemsAsync.fulfilled, (state, action) => {
+        state.status = 'idle';
+        state.items = action.payload as [];
+      })
+      .addCase(loadCuTableItemsAsync.rejected, (state) => {
+        state.status = 'idle';
+      });
+  },
 });
 
-export const { clearTable } = cuTableSlice.actions;
+export const { clearTable, resetHeaderSorting, setSortColumn, setSort } =
+  cuTableSlice.actions;
 
 export const selectCuTableItems = (state: RootState) => state.cuTable.items;
 export const selectCuTableStatus = (state: RootState) => state.cuTable.status;
+export const selectCuTableSortColumn = (state: RootState) => state.cuTable.sortColumn;
+export const selectCuTableHeadersSort = (state: RootState) => state.cuTable.headersSort;
 
 export default cuTableSlice.reducer;

--- a/src/stories/containers/cu-table/cu-table.stories.tsx
+++ b/src/stories/containers/cu-table/cu-table.stories.tsx
@@ -3,7 +3,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { CuTable } from './cu-table';
 import { Provider } from 'react-redux';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
-import { CuTableState } from './cu-table.slice';
+import { CuTableState, sortNeutralState } from './cu-table.slice';
 import { initialState } from './cu-table.stories.states';
 
 const store = configureStore({
@@ -19,6 +19,8 @@ const store = configureStore({
 const MockedState: CuTableState = {
   items: [],
   status: 'idle',
+  sortColumn: 0,
+  headersSort: sortNeutralState
 };
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
# Ticket
https://trello.com/c/QJFWbzL0/110-general-issues-detected-in-the-uat-coreunitaboutpage-r

# Description
When a user filters on the core unit index table and then clicks into the specific core unit. The filter is not reflected when a user toggles back to the previous, or ahead to the next core unit, so this behavior was changed to reflect the filters

# Actions
- The ordering logic was moved to redux
- The sorting CU function was moved out of the CU table so it can be reused
- The pagination now works by applying the filters and orderings in the CU table