### PR TITLE
[SES] Make CU about pages fully SSR

### DIFF
--- a/pages/core-unit/[code]/finances/reports/index.tsx
+++ b/pages/core-unit/[code]/finances/reports/index.tsx
@@ -1,18 +1,19 @@
 import { GetServerSidePropsContext } from 'next';
 import React from 'react';
 import { CoreUnitDto } from '../../../../../src/core/models/dto/core-unit.dto';
+import { fetchCoreUnits } from '../../../../../src/stories/components/core-unit-summary/core-unit-summary.mvvm';
 import { TransparencyReport } from '../../../../../src/stories/containers/transparency-report/transparency-report';
 import { useTransparencyReportViewModel } from '../../../../../src/stories/containers/transparency-report/transparency-report.mvvm';
 
-export const getServerSideProps = async(
-  context: GetServerSidePropsContext
-) => {
+export const getServerSideProps = async(context: GetServerSidePropsContext) => {
   const { query } = context;
   const code = query.code as string;
-  const { data }: { data: { coreUnit: CoreUnitDto[] } } =
-    await useTransparencyReportViewModel(code);
+  const [{ data }, coreUnits] = await Promise.all([
+    useTransparencyReportViewModel(code),
+    fetchCoreUnits()
+  ]);
 
-  if (data && data.coreUnit.length === 0) {
+  if (data?.coreUnit?.length === 0) {
     return {
       notFound: true,
     };
@@ -20,13 +21,19 @@ export const getServerSideProps = async(
 
   return {
     props: {
-      cu: data && data.coreUnit[0],
+      coreUnits,
+      cu: data.coreUnit[0],
     },
   };
 };
 
-const Transparency = ({ cu }: { cu: CoreUnitDto }) => {
-  return <TransparencyReport coreUnit={cu} />;
+interface TransparencyProps {
+  coreUnits: CoreUnitDto[],
+  cu: CoreUnitDto
+}
+
+const Transparency = ({ coreUnits, cu }: TransparencyProps) => {
+  return <TransparencyReport coreUnits={coreUnits} coreUnit={cu} />;
 };
 
 export default Transparency;

--- a/pages/core-unit/[code]/finances/reports/index.tsx
+++ b/pages/core-unit/[code]/finances/reports/index.tsx
@@ -1,7 +1,7 @@
 import { GetServerSidePropsContext } from 'next';
 import React from 'react';
 import { CoreUnitDto } from '../../../../../src/core/models/dto/core-unit.dto';
-import { fetchCoreUnits } from '../../../../../src/stories/components/core-unit-summary/core-unit-summary.mvvm';
+import { fetchCoreUnits, SummarizedCoreUnit } from '../../../../../src/stories/components/core-unit-summary/core-unit-summary.mvvm';
 import { TransparencyReport } from '../../../../../src/stories/containers/transparency-report/transparency-report';
 import { useTransparencyReportViewModel } from '../../../../../src/stories/containers/transparency-report/transparency-report.mvvm';
 
@@ -28,7 +28,7 @@ export const getServerSideProps = async(context: GetServerSidePropsContext) => {
 };
 
 interface TransparencyProps {
-  coreUnits: CoreUnitDto[],
+  coreUnits: SummarizedCoreUnit[],
   cu: CoreUnitDto
 }
 

--- a/pages/core-unit/[code]/index.tsx
+++ b/pages/core-unit/[code]/index.tsx
@@ -4,17 +4,22 @@ import _ from 'lodash';
 
 import CuAboutContainer from '../../../src/stories/containers/cu-about/cu-about-container';
 import { CuAbout, fetchCoreUnitByCode } from '../../../src/stories/containers/cu-about/cu-about.api';
+import { fetchCoreUnits } from '../../../src/stories/components/core-unit-summary/core-unit-summary.mvvm';
 
-const CoreUnitAboutPage: NextPage = ({ code, cuAbout, contributors }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+const CoreUnitAboutPage: NextPage = ({ code, coreUnits, cuAbout, contributors }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   return (
-    <CuAboutContainer code={code} cuAbout={cuAbout as CuAbout} contributors={contributors} />
+    <CuAboutContainer code={code} coreUnits={coreUnits} cuAbout={cuAbout as CuAbout} contributors={contributors} />
   );
 };
 export default CoreUnitAboutPage;
 export const getServerSideProps: GetServerSideProps = async(context: GetServerSidePropsContext) => {
   const { query } = context;
   const code = query.code as string;
-  const cuAbout = await fetchCoreUnitByCode(code);
+
+  const [cuAbout, coreUnits] = await Promise.all([
+    fetchCoreUnitByCode(code),
+    fetchCoreUnits()
+  ]);
   const contributorCommitment = cuAbout?.contributorCommitment;
 
   if (_.isEmpty(cuAbout)) {
@@ -26,6 +31,7 @@ export const getServerSideProps: GetServerSideProps = async(context: GetServerSi
   return {
     props: {
       code,
+      coreUnits,
       cuAbout: cuAbout || {},
       contributors: contributorCommitment || [],
     }

--- a/src/stories/components/core-unit-summary/core-unit-summary.mvvm.ts
+++ b/src/stories/components/core-unit-summary/core-unit-summary.mvvm.ts
@@ -45,6 +45,15 @@ const CORE_UNITS_REQUEST = {
           linkedIn
           website
         }
+        budgetStatements {
+          month
+          budgetStatementWallet {
+            budgetStatementLineItem {
+              actual
+              month
+            }
+          }
+        }
       }
    }
 `

--- a/src/stories/components/core-unit-summary/core-unit-summary.mvvm.ts
+++ b/src/stories/components/core-unit-summary/core-unit-summary.mvvm.ts
@@ -2,7 +2,19 @@ import useSWRImmutable from 'swr/immutable';
 import { fetcher } from '../../../core/utils/fetcher';
 import request, { gql } from 'graphql-request';
 import { GRAPHQL_ENDPOINT } from '../../../config/endpoints';
-import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
+import type { CuMipDto, SocialMediaChannelDto } from '../../../core/models/dto/core-unit.dto';
+
+export interface SummarizedCoreUnit {
+  id: string;
+  shortCode: string;
+  code: string;
+  name: string;
+  image: string;
+  sentenceDescription: string;
+  category: string[];
+  cuMip: CuMipDto[];
+  socialMediaChannels: SocialMediaChannelDto[];
+}
 
 const CORE_UNITS_REQUEST = {
   query: gql`
@@ -33,27 +45,13 @@ const CORE_UNITS_REQUEST = {
           linkedIn
           website
         }
-        budgetStatements {
-          month
-          budgetStatementFTEs {
-            month
-            ftes
-          }
-          budgetStatus,
-          budgetStatementWallet {
-            budgetStatementLineItem {
-              actual
-              month
-            }
-          }
-        }
       }
    }
 `
 };
 
 export const fetchCoreUnits = async() => {
-  const res = (await request(GRAPHQL_ENDPOINT, CORE_UNITS_REQUEST.query)) as { coreUnits: CoreUnitDto[]};
+  const res = (await request(GRAPHQL_ENDPOINT, CORE_UNITS_REQUEST.query)) as { coreUnits: SummarizedCoreUnit[]};
   return res?.coreUnits;
 };
 

--- a/src/stories/components/core-unit-summary/core-unit-summary.mvvm.ts
+++ b/src/stories/components/core-unit-summary/core-unit-summary.mvvm.ts
@@ -1,6 +1,8 @@
 import useSWRImmutable from 'swr/immutable';
 import { fetcher } from '../../../core/utils/fetcher';
-import { gql } from 'graphql-request';
+import request, { gql } from 'graphql-request';
+import { GRAPHQL_ENDPOINT } from '../../../config/endpoints';
+import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
 
 const CORE_UNITS_REQUEST = {
   query: gql`
@@ -48,6 +50,11 @@ const CORE_UNITS_REQUEST = {
       }
    }
 `
+};
+
+export const fetchCoreUnits = async() => {
+  const res = (await request(GRAPHQL_ENDPOINT, CORE_UNITS_REQUEST.query)) as { coreUnits: CoreUnitDto[]};
+  return res?.coreUnits;
 };
 
 export const useCoreUnitSummaryViewModel = () => {

--- a/src/stories/components/core-unit-summary/core-unit-summary.tsx
+++ b/src/stories/components/core-unit-summary/core-unit-summary.tsx
@@ -5,7 +5,6 @@ import { Typography, useMediaQuery } from '@mui/material';
 import styled from '@emotion/styled';
 import { filterData, getArrayParam, getStringParam } from '../../../core/utils/filters';
 import { useRouter } from 'next/router';
-import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
 import _ from 'lodash';
 import lightTheme from '../../../../styles/theme/light';
 import BreadCrumbMobile from '../pagination/bread-crumb-mobile';
@@ -14,9 +13,11 @@ import { useThemeContext } from '../../../core/context/ThemeContext';
 import { formatCode } from '../../../core/utils/string.utils';
 import { buildQueryString } from '../../../core/utils/url.utils';
 import { sortData } from '../../containers/cu-table/cu-table';
+import { SummarizedCoreUnit } from './core-unit-summary.mvvm';
+import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
 
 interface CoreUnitSummaryProps {
-  coreUnits: CoreUnitDto[],
+  coreUnits: SummarizedCoreUnit[],
   trailingAddress?: string[];
   breadcrumbTitle?: string;
 }
@@ -57,7 +58,7 @@ export const CoreUnitSummary = ({ coreUnits: data = [], trailingAddress = [], br
 
   const filteredData = useMemo(() => {
     const { filteredData: filtered } = filterData({
-      data,
+      data: data as CoreUnitDto[],
       filteredStatuses,
       filteredCategories,
       searchText

--- a/src/stories/components/core-unit-summary/core-unit-summary.tsx
+++ b/src/stories/components/core-unit-summary/core-unit-summary.tsx
@@ -6,7 +6,6 @@ import styled from '@emotion/styled';
 import { filterData, getArrayParam, getStringParam } from '../../../core/utils/filters';
 import { useRouter } from 'next/router';
 import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
-import { useCoreUnitSummaryViewModel } from './core-unit-summary.mvvm';
 import _ from 'lodash';
 import lightTheme from '../../../../styles/theme/light';
 import BreadCrumbMobile from '../pagination/bread-crumb-mobile';
@@ -17,11 +16,12 @@ import { buildQueryString } from '../../../core/utils/url.utils';
 import { sortData } from '../../containers/cu-table/cu-table';
 
 interface CoreUnitSummaryProps {
+  coreUnits: CoreUnitDto[],
   trailingAddress?: string[];
   breadcrumbTitle?: string;
 }
 
-export const CoreUnitSummary = ({ trailingAddress = [], breadcrumbTitle }: CoreUnitSummaryProps) => {
+export const CoreUnitSummary = ({ coreUnits: data = [], trailingAddress = [], breadcrumbTitle }: CoreUnitSummaryProps) => {
   const isLight = useThemeContext().themeMode === 'light';
   const phone = useMediaQuery(lightTheme.breakpoints.between('table_375', 'table_834'));
   const lessThanPhone = useMediaQuery(lightTheme.breakpoints.down('table_375'));
@@ -30,9 +30,6 @@ export const CoreUnitSummary = ({ trailingAddress = [], breadcrumbTitle }: CoreU
   const query = router.query;
   const code = query.code as string;
 
-  const { data: response } = useCoreUnitSummaryViewModel();
-
-  const data: CoreUnitDto[] = response?.coreUnits as CoreUnitDto[];
   const filteredStatuses = useMemo(() => getArrayParam('filteredStatuses', router.query), [router.query]);
   const filteredCategories = useMemo(() => getArrayParam('filteredCategories', router.query), [router.query]);
   const searchText = useMemo(() => getStringParam('searchText', router.query), [router.query]);

--- a/src/stories/components/markdown/renderUtils.tsx
+++ b/src/stories/components/markdown/renderUtils.tsx
@@ -97,8 +97,9 @@ const ImageTag = styled.img({
   margin: '0 auto',
 });
 
-const ResponsiveParagraph = styled.p({
+const ResponsiveParagraph = styled.div({
   textAlign: 'left',
+  marginTop: '1em',
 
   [lightTheme.breakpoints.between('table_375', 'table_834')]: {
     fontSize: '14px',

--- a/src/stories/components/title-navigation-cu-about/title-navigation-cu-about.stories.tsx
+++ b/src/stories/components/title-navigation-cu-about/title-navigation-cu-about.stories.tsx
@@ -2,7 +2,9 @@ import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import TitleNavigationCuAbout from './title-navigation-cu-about';
 import { CuStatusEnum } from '../../../core/enums/cu-status.enum';
-import { CuAbout, CuMip, SocialMediaChannels } from '../../containers/cu-about/cu-about.api';
+import { SocialMediaChannels } from '../../containers/cu-about/cu-about.api';
+import { SummarizedCoreUnit } from '../core-unit-summary/core-unit-summary.mvvm';
+import { CuMipDto } from '../../../core/models/dto/core-unit.dto';
 
 export default {
   title: 'Components/CUAbout/TitleNavigationCuAbout',
@@ -41,10 +43,8 @@ Default.args = {
         mipUrl: 'https://makerdao.com/',
         mipStatus: CuStatusEnum.Accepted,
       }
-    ] as CuMip[],
-    budgetStatements: [],
-    contributorCommitment: [],
-  } as CuAbout
+    ] as CuMipDto[],
+  } as SummarizedCoreUnit
 };
 
 DataWith.args = {
@@ -54,6 +54,7 @@ DataWith.args = {
     code: 'SES-001',
     category: ['Technical', 'Support', 'Operational'],
     name: 'Sustainable Ecosystem Scaling',
+    image: 'https://makerdao-ses.github.io/ecosystem-dashboard/core-units/ses-001/logo.png',
     sentenceDescription: '',
     paragraphDescription: '',
     paragraphImage: '',
@@ -75,8 +76,6 @@ DataWith.args = {
         mipUrl: 'https://makerdao.com/',
         mipStatus: CuStatusEnum.Obsolete,
       }
-    ] as CuMip[],
-    budgetStatements: [],
-    contributorCommitment: [],
-  } as CuAbout
+    ] as CuMipDto[],
+  } as SummarizedCoreUnit
 };

--- a/src/stories/components/title-navigation-cu-about/title-navigation-cu-about.tsx
+++ b/src/stories/components/title-navigation-cu-about/title-navigation-cu-about.tsx
@@ -8,7 +8,7 @@ import {
 } from '../cu-table-column-links/cu-table-column-links';
 import { CuStatusEnum } from '../../../core/enums/cu-status.enum';
 import { StatusChip } from '../status-chip/status-chip';
-import { CuAbout, CuMip } from '../../containers/cu-about/cu-about.api';
+import { CuMip } from '../../containers/cu-about/cu-about.api';
 import { LinkTypeEnum } from '../../../core/enums/link-type.enum';
 import { CategoryChip } from '../category-chip/category-chip';
 import {
@@ -23,6 +23,7 @@ import { CustomLink } from '../custom-link/custom-link';
 import lightTheme from '../../../../styles/theme/light';
 import { useThemeContext } from '../../../core/context/ThemeContext';
 import { getLatestMip39FromCoreUnit, getSubmissionDateFromCuMip } from '../../../core/business-logic/core-units';
+import { SummarizedCoreUnit } from '../core-unit-summary/core-unit-summary.mvvm';
 
 interface BudgetStatementFTEs {
   month: string;
@@ -55,11 +56,11 @@ export interface CoreUnit {
   roadMap: [];
 }
 interface Props {
-  coreUnitAbout?: CuAbout | CoreUnitDto;
+  coreUnitAbout?: SummarizedCoreUnit;
   hiddenTextDescription?: boolean;
 }
 
-export const getLinksCoreUnit = (cu: CuAbout | CoreUnitDto) => {
+export const getLinksCoreUnit = (cu: CoreUnitDto) => {
   const links: LinkModel[] = [];
   if (cu.socialMediaChannels.length === 0) return links;
   const cont = cu.socialMediaChannels[0];
@@ -217,7 +218,7 @@ export const TitleNavigationCuAbout = ({
           {(phoneDimensions || lessPhone || tableDimensions) && hiddenTextDescription && (
             <ContainerLinks>
               <CuTableColumnLinks
-                links={getLinksCoreUnit(coreUnitAbout)}
+                links={getLinksCoreUnit(coreUnitAbout as CoreUnitDto)}
                 fill="#708390"
                 align="flex-start"
                 spacings={16}
@@ -230,7 +231,7 @@ export const TitleNavigationCuAbout = ({
       {!(phoneDimensions || lessPhone || tableDimensions) && (
         <ContainerLinks>
           <CuTableColumnLinks
-            links={getLinksCoreUnit(coreUnitAbout)}
+            links={getLinksCoreUnit(coreUnitAbout as CoreUnitDto)}
             fill="#708390"
             spacings={16}
             fillDark="#ADAFD4"

--- a/src/stories/containers/cu-about/cu-about-container.tsx
+++ b/src/stories/containers/cu-about/cu-about-container.tsx
@@ -23,15 +23,17 @@ import { useThemeContext } from '../../../core/context/ThemeContext';
 import dynamic from 'next/dynamic';
 import { SEOHead } from '../../components/seo-head/seo-head';
 import { buildQueryString, toAbsoluteURL } from '../../../core/utils/url.utils';
+import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
 const MdViewerContainer = dynamic(() => import('../../components/markdown/md-view-container'), { ssr: false });
 
 interface Props {
+  coreUnits: CoreUnitDto[],
   cuAbout: CuAbout;
   code: string;
   contributors: ContributorCommitment[]
 }
 
-const CuAboutContainer = ({ code, cuAbout, contributors }: Props) => {
+const CuAboutContainer = ({ code, coreUnits, cuAbout, contributors }: Props) => {
   const [isEnabled] = useFlagsActive();
   const isLight = useThemeContext().themeMode === 'light';
   const router = useRouter();
@@ -82,7 +84,7 @@ const CuAboutContainer = ({ code, cuAbout, contributors }: Props) => {
         twitterCard={cuAbout.image ? 'summary' : 'summary_large_image'}
       />
 
-      <CoreUnitSummary />
+      <CoreUnitSummary coreUnits={coreUnits} />
       <Wrapper>
         <ContainerAllData>
           <ContainerResponsive>

--- a/src/stories/containers/cu-about/cu-about-container.tsx
+++ b/src/stories/containers/cu-about/cu-about-container.tsx
@@ -23,11 +23,11 @@ import { useThemeContext } from '../../../core/context/ThemeContext';
 import dynamic from 'next/dynamic';
 import { SEOHead } from '../../components/seo-head/seo-head';
 import { buildQueryString, toAbsoluteURL } from '../../../core/utils/url.utils';
-import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
+import { SummarizedCoreUnit } from '../../components/core-unit-summary/core-unit-summary.mvvm';
 const MdViewerContainer = dynamic(() => import('../../components/markdown/md-view-container'), { ssr: false });
 
 interface Props {
-  coreUnits: CoreUnitDto[],
+  coreUnits: SummarizedCoreUnit[],
   cuAbout: CuAbout;
   code: string;
   contributors: ContributorCommitment[]

--- a/src/stories/containers/cu-about/cu-about-container.tsx
+++ b/src/stories/containers/cu-about/cu-about-container.tsx
@@ -20,11 +20,10 @@ import { useFlagsActive } from '../../../core/hooks/useFlagsActive';
 import { formatCode } from '../../../core/utils/string.utils';
 import { CuStatusEnum } from '../../../core/enums/cu-status.enum';
 import { useThemeContext } from '../../../core/context/ThemeContext';
-import dynamic from 'next/dynamic';
 import { SEOHead } from '../../components/seo-head/seo-head';
 import { buildQueryString, toAbsoluteURL } from '../../../core/utils/url.utils';
 import { SummarizedCoreUnit } from '../../components/core-unit-summary/core-unit-summary.mvvm';
-const MdViewerContainer = dynamic(() => import('../../components/markdown/md-view-container'), { ssr: false });
+import MdViewerContainer from '../../components/markdown/md-view-container';
 
 interface Props {
   coreUnits: SummarizedCoreUnit[],

--- a/src/stories/containers/cu-about/cu-about.stories.tsx
+++ b/src/stories/containers/cu-about/cu-about.stories.tsx
@@ -7,15 +7,18 @@ import { CurrentCoreUnitAbout, initialState } from './cu-about-slice';
 import { initialState as cuTableInitialState } from '../../containers/cu-table/cu-table.stories.states';
 import { HeaderWrapper } from '../dashboard-wrapper/header-wrapper';
 import { CuAbout } from './cu-about.api';
+import { SummarizedCoreUnit } from '../../components/core-unit-summary/core-unit-summary.mvvm';
 
 export default {
   title: 'Containers/CuAboutContainer',
   component: CuAboutContainer,
   parameters: {
     layout: 'fullscreen',
-  }
+  },
 } as ComponentMeta<typeof CuAboutContainer>;
-const Template: ComponentStory<typeof CuAboutContainer> = () => <CuAboutContainer code='SES-01' contributors={[]} cuAbout={{} as CuAbout} />;
+const Template: ComponentStory<typeof CuAboutContainer> = () => (
+  <CuAboutContainer code="SES-01" contributors={[]} coreUnits={[] as SummarizedCoreUnit[]} cuAbout={{} as CuAbout} />
+);
 export const CuAboutPage = Template.bind({});
 
 const store = configureStore({
@@ -23,14 +26,14 @@ const store = configureStore({
     cuAbout: createSlice({
       name: 'cuAbout',
       initialState,
-      reducers: {}
+      reducers: {},
     }).reducer,
     cuTable: createSlice({
       name: 'cuTable',
       initialState: cuTableInitialState,
-      reducers: {}
-    }).reducer
-  }
+      reducers: {},
+    }).reducer,
+  },
 });
 
 const MockedState: CurrentCoreUnitAbout = initialState;
@@ -39,14 +42,11 @@ const MockedState: CurrentCoreUnitAbout = initialState;
 // @ts-ignore
 // eslint-disable-next-line react/prop-types
 const Mockstore = ({ children }) => (
-  <Provider
-    store={store}>
-    {children}
-  </Provider>
+  <Provider store={store}>{children}</Provider>
 );
 CuAboutPage.decorators = [
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  (story) => <HeaderWrapper><Mockstore cuAbout={MockedState}>{story()}</Mockstore></HeaderWrapper>
+  (story) => <HeaderWrapper><Mockstore cuAbout={MockedState}>{story()}</Mockstore></HeaderWrapper>,
 ];
 CuAboutPage.args = {};

--- a/src/stories/containers/transparency-report/transparency-report.tsx
+++ b/src/stories/containers/transparency-report/transparency-report.tsx
@@ -24,6 +24,7 @@ import { useUrlAnchor } from '../../../core/hooks/useUrlAnchor';
 import { getCurrentOrLastMonthWithData, getLastMonthWithActualOrForecast } from '../../../core/business-logic/core-units';
 import { toAbsoluteURL } from '../../../core/utils/url.utils';
 import lightTheme from '../../../../styles/theme/light';
+import { SummarizedCoreUnit } from '../../components/core-unit-summary/core-unit-summary.mvvm';
 
 const colors: { [key: string]: string } = {
   Draft: '#7C6B95',
@@ -42,7 +43,7 @@ const colorsDarkColors: { [key: string]: string } = {
 const TRANSPARENCY_IDS = ['actuals', 'forecast', 'mkr-vesting', 'transfer-requests', 'audit-reports'];
 
 interface TransparencyReportProps {
-  coreUnits: CoreUnitDto[];
+  coreUnits: SummarizedCoreUnit[];
   coreUnit: CoreUnitDto;
 }
 

--- a/src/stories/containers/transparency-report/transparency-report.tsx
+++ b/src/stories/containers/transparency-report/transparency-report.tsx
@@ -41,11 +41,15 @@ const colorsDarkColors: { [key: string]: string } = {
 
 const TRANSPARENCY_IDS = ['actuals', 'forecast', 'mkr-vesting', 'transfer-requests', 'audit-reports'];
 
-export const TransparencyReport = ({
-  coreUnit: cu,
-}: {
+interface TransparencyReportProps {
+  coreUnits: CoreUnitDto[];
   coreUnit: CoreUnitDto;
-}) => {
+}
+
+export const TransparencyReport = ({
+  coreUnits,
+  coreUnit: cu,
+}: TransparencyReportProps) => {
   const isLight = useThemeContext().themeMode === 'light';
   const router = useRouter();
   const query = router.query;
@@ -149,7 +153,10 @@ export const TransparencyReport = ({
         image={cu.image || toAbsoluteURL('/assets/img/social-1200x630.png')}
         twitterCard={cu.image ? 'summary' : 'summary_large_image'}
       />
-      <CoreUnitSummary trailingAddress={['Expense Reports']} breadcrumbTitle="Expense Reports" />
+      <CoreUnitSummary
+        coreUnits={coreUnits}
+        trailingAddress={['Expense Reports']}
+        breadcrumbTitle="Expense Reports" />
       <Container isLight={isLight}>
         <InnerPage>
           <Title isLight={isLight}>Expense Reports</Title>
@@ -183,7 +190,7 @@ export const TransparencyReport = ({
                 onNext={handleNextMonth}
                 hasNext={hasNextMonth()}
               />
-              {currentBudgetStatement?.publicationUrl.trim() && (
+              {currentBudgetStatement?.publicationUrl?.trim() && (
                 <CustomLink
                   href={currentBudgetStatement?.publicationUrl ?? null}
                   style={{

--- a/src/stories/containers/transparency-report/transpareny-report.stories.tsx
+++ b/src/stories/containers/transparency-report/transpareny-report.stories.tsx
@@ -2,14 +2,19 @@ import React from 'react';
 import { TransparencyReport } from './transparency-report';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 import { CoreUnitDto } from '../../../core/models/dto/core-unit.dto';
+import { SummarizedCoreUnit } from '../../components/core-unit-summary/core-unit-summary.mvvm';
 
 export default {
   title: 'Containers/TransparencyReport',
   component: TransparencyReport,
 } as ComponentMeta<typeof TransparencyReport>;
 
-const Template: ComponentStory<typeof TransparencyReport> = () => <TransparencyReport coreUnit={{} as CoreUnitDto}/>;
+const Template: ComponentStory<typeof TransparencyReport> = () => (
+  <TransparencyReport
+    coreUnits={[] as SummarizedCoreUnit[]}
+    coreUnit={{} as CoreUnitDto}
+  />
+);
 
 export const Default = Template.bind({});
-Default.args = {
-};
+Default.args = {};

--- a/src/stories/pages/page/cu-about/cu-about.tsx
+++ b/src/stories/pages/page/cu-about/cu-about.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import { SummarizedCoreUnit } from '../../../components/core-unit-summary/core-unit-summary.mvvm';
 import CuAboutContainer from '../../../containers/cu-about/cu-about-container';
 import { CuAbout } from '../../../containers/cu-about/cu-about.api';
 const CuAboutPageTesting = () => {
   return (
-    <CuAboutContainer cuAbout={{} as CuAbout} code='SES-001' contributors={[]}/>);
+    <CuAboutContainer coreUnits={[] as SummarizedCoreUnit[]} cuAbout={{} as CuAbout} code='SES-001' contributors={[]}/>
+  );
 };
 
 export default CuAboutPageTesting;


### PR DESCRIPTION
# Ticket
NO TICKET

# Description
Moved all queries previously done on the client side to the Server Side

# Actions
- Moved queries from core-unit-summary to SSR in CU about page
- Moved queries from core-unit-summary to SSR on CU transparency report page
- Removed `budgetStatements` from the `core-unit-summary` query to reduce the weight of the data fetched
- Apply SSR to the markdown elements in the CU about page