### PR TITLE
[FIX-189] Fix 404 message flicker on auth related routes on refresh

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement, ReactNode, useEffect } from 'react';
 import { Provider } from 'react-redux';
+import isEmpty from 'lodash/isEmpty';
 import type { AppProps } from 'next/app';
 import { store } from '../src/core/store/store';
 import '../styles/globals.scss';
@@ -15,6 +16,7 @@ import * as gtag from '../src/core/utils/gtag';
 import { CookiesProviderTracking } from '../src/core/context/CookiesContext';
 import { CookiesProvider, useCookies } from 'react-cookie';
 import { AuthContextProvider } from '../src/core/context/AuthContext';
+import { getAuthFromStorage } from '../src/core/utils/auth-storage';
 
 export type NextPageWithLayout = NextPage & {
   getLayout?: (page: ReactElement) => ReactNode;
@@ -23,6 +25,7 @@ export type NextPageWithLayout = NextPage & {
 interface MyAppProps extends AppProps {
   Component: NextPageWithLayout;
   emotionCache?: EmotionCache;
+  protected?: boolean;
 }
 
 function MyApp(props: MyAppProps) {
@@ -40,6 +43,14 @@ function MyApp(props: MyAppProps) {
       };
     }
   }, [router.events]);
+
+  useEffect(() => {
+    const authData = getAuthFromStorage();
+    if (props.pageProps.protected && (isEmpty(authData) || !authData?.authToken)) {
+      router.push('/login');
+    }
+  }, []);
+
   return (
     <CookiesProvider>
       <Provider store={store}>

--- a/pages/auth/change-password/index.tsx
+++ b/pages/auth/change-password/index.tsx
@@ -1,21 +1,13 @@
 import styled from '@emotion/styled';
 import { NextPage } from 'next';
 import React from 'react';
-import { featureFlags } from '../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../src/config/endpoints';
-import { useAuthContext } from '../../../src/core/context/AuthContext';
 import { useThemeContext } from '../../../src/core/context/ThemeContext';
+import { getSSRPropsDefaultAuth } from '../../../src/core/utils/common-get-ssr-props';
 import ChangePassword from '../../../src/stories/containers/auth/change-password/change-password';
 import lightTheme from '../../../styles/theme/light';
-import NotFoundPage from '../../404';
 
 const ChangePasswordPage: NextPage = () => {
-  const { authToken } = useAuthContext();
   const { isLight } = useThemeContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !authToken) {
-    return <NotFoundPage />;
-  }
 
   return (
     <Container isLight={isLight}>
@@ -25,6 +17,8 @@ const ChangePasswordPage: NextPage = () => {
 };
 
 export default ChangePasswordPage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;
 
 export const Container = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   display: 'flex',

--- a/pages/auth/create-account/index.tsx
+++ b/pages/auth/create-account/index.tsx
@@ -1,20 +1,11 @@
 import { NextPage } from 'next';
 import React from 'react';
-import { featureFlags } from '../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../src/config/endpoints';
 import CreateAccount from '../../../src/stories/containers/users/create-account/create-account';
-import NotFoundPage from '../../404';
-import { useAuthContext } from '../../../src/core/context/AuthContext';
 import UserManagerLayout from '../../../src/stories/containers/users/users-manager/user-manager-layout';
 import { ManagerTabs } from '../../../src/stories/containers/users/users-manager/manager-tabs.enum';
+import { getSSRPropsDefaultAuth } from '../../../src/core/utils/common-get-ssr-props';
 
 const CreateAccountPage: NextPage = () => {
-  const { authToken, isAdmin } = useAuthContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !authToken || !isAdmin) {
-    return <NotFoundPage />;
-  }
-
   return (
     <UserManagerLayout tabIndex={ManagerTabs.MANAGER}>
       <CreateAccount />
@@ -23,3 +14,5 @@ const CreateAccountPage: NextPage = () => {
 };
 
 export default CreateAccountPage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;

--- a/pages/auth/delete-account/index.tsx
+++ b/pages/auth/delete-account/index.tsx
@@ -1,21 +1,15 @@
 import styled from '@emotion/styled';
 import { NextPage } from 'next';
 import React from 'react';
-import { featureFlags } from '../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../src/config/endpoints';
 import { useAuthContext } from '../../../src/core/context/AuthContext';
 import { useThemeContext } from '../../../src/core/context/ThemeContext';
+import { getSSRPropsDefaultAuth } from '../../../src/core/utils/common-get-ssr-props';
 import DeleteAccount from '../../../src/stories/containers/users/delete-account/delete-account';
 import lightTheme from '../../../styles/theme/light';
-import NotFoundPage from '../../404';
 
 const CreateAccountPage: NextPage = () => {
-  const { authToken, user } = useAuthContext();
+  const { user } = useAuthContext();
   const { isLight } = useThemeContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !authToken) {
-    return <NotFoundPage />;
-  }
 
   return (
     <Container isLight={isLight}>
@@ -25,6 +19,8 @@ const CreateAccountPage: NextPage = () => {
 };
 
 export default CreateAccountPage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;
 
 export const Container = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   display: 'flex',

--- a/pages/auth/manage/accounts.tsx
+++ b/pages/auth/manage/accounts.tsx
@@ -1,5 +1,6 @@
 import { NextPage } from 'next';
 import React from 'react';
+import { getSSRPropsDefaultAuth } from '../../../src/core/utils/common-get-ssr-props';
 import ManageAccounts from '../../../src/stories/containers/users/manage-accounts/manage-accounts';
 import { ManagerTabs } from '../../../src/stories/containers/users/users-manager/manager-tabs.enum';
 import UserManagerLayout from '../../../src/stories/containers/users/users-manager/user-manager-layout';
@@ -13,3 +14,5 @@ const ManageAccountsPage: NextPage = () => {
 };
 
 export default ManageAccountsPage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;

--- a/pages/auth/manage/change-my-password.tsx
+++ b/pages/auth/manage/change-my-password.tsx
@@ -4,19 +4,10 @@ import React from 'react';
 import { ManagerTabs } from '../../../src/stories/containers/users/users-manager/manager-tabs.enum';
 import UserManagerLayout from '../../../src/stories/containers/users/users-manager/user-manager-layout';
 import lightTheme from '../../../styles/theme/light';
-import { useAuthContext } from '../../../src/core/context/AuthContext';
-import { featureFlags } from '../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../src/config/endpoints';
-import NotFoundPage from '../../404';
 import ChangePassword from '../../../src/stories/containers/auth/change-password/change-password';
+import { getSSRPropsDefaultAuth } from '../../../src/core/utils/common-get-ssr-props';
 
 const ChangeMyPasswordPage: NextPage = () => {
-  const { authToken, isAdmin } = useAuthContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !isAdmin || !authToken) {
-    return <NotFoundPage />;
-  }
-
   return (
     <UserManagerLayout tabIndex={ManagerTabs.PROFILE}>
       <Container>
@@ -25,6 +16,10 @@ const ChangeMyPasswordPage: NextPage = () => {
     </UserManagerLayout>
   );
 };
+
+export default ChangeMyPasswordPage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;
 
 const Container = styled.div({
   display: 'flex',
@@ -35,5 +30,3 @@ const Container = styled.div({
     marginTop: 24,
   },
 });
-
-export default ChangeMyPasswordPage;

--- a/pages/auth/manage/delete-my-account.tsx
+++ b/pages/auth/manage/delete-my-account.tsx
@@ -5,17 +5,11 @@ import { ManagerTabs } from '../../../src/stories/containers/users/users-manager
 import UserManagerLayout from '../../../src/stories/containers/users/users-manager/user-manager-layout';
 import lightTheme from '../../../styles/theme/light';
 import { useAuthContext } from '../../../src/core/context/AuthContext';
-import { featureFlags } from '../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../src/config/endpoints';
-import NotFoundPage from '../../404';
 import DeleteAccount from '../../../src/stories/containers/users/delete-account/delete-account';
+import { getSSRPropsDefaultAuth } from '../../../src/core/utils/common-get-ssr-props';
 
 const DeleteMyAccount: NextPage = () => {
-  const { authToken, isAdmin, user } = useAuthContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !isAdmin || !authToken) {
-    return <NotFoundPage />;
-  }
+  const { user } = useAuthContext();
 
   return (
     <UserManagerLayout tabIndex={ManagerTabs.PROFILE}>
@@ -26,6 +20,10 @@ const DeleteMyAccount: NextPage = () => {
   );
 };
 
+export default DeleteMyAccount;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;
+
 const Container = styled.div({
   display: 'flex',
   flexDirection: 'row',
@@ -35,5 +33,3 @@ const Container = styled.div({
     marginTop: 24,
   },
 });
-
-export default DeleteMyAccount;

--- a/pages/auth/manage/my-profile.tsx
+++ b/pages/auth/manage/my-profile.tsx
@@ -5,6 +5,7 @@ import { ManagerTabs } from '../../../src/stories/containers/users/users-manager
 import UserManagerLayout from '../../../src/stories/containers/users/users-manager/user-manager-layout';
 import UserProfile from '../../../src/stories/containers/users/user-profile/user-profile';
 import lightTheme from '../../../styles/theme/light';
+import { getSSRPropsDefaultAuth } from '../../../src/core/utils/common-get-ssr-props';
 
 const MyProfilePage: NextPage = () => {
   return (
@@ -16,6 +17,10 @@ const MyProfilePage: NextPage = () => {
   );
 };
 
+export default MyProfilePage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;
+
 const ContainerProfile = styled.div({
   display: 'flex',
   flexDirection: 'row',
@@ -25,5 +30,3 @@ const ContainerProfile = styled.div({
     marginTop: 24,
   },
 });
-
-export default MyProfilePage;

--- a/pages/auth/manage/user/[username]/change-password.tsx
+++ b/pages/auth/manage/user/[username]/change-password.tsx
@@ -4,19 +4,10 @@ import React from 'react';
 import { ManagerTabs } from '../../../../../src/stories/containers/users/users-manager/manager-tabs.enum';
 import UserManagerLayout from '../../../../../src/stories/containers/users/users-manager/user-manager-layout';
 import lightTheme from '../../../../../styles/theme/light';
-import { useAuthContext } from '../../../../../src/core/context/AuthContext';
-import { featureFlags } from '../../../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../../../src/config/endpoints';
-import NotFoundPage from '../../../../404';
 import ChangePassword from '../../../../../src/stories/containers/auth/change-password/change-password';
+import { getSSRPropsDefaultAuth } from '../../../../../src/core/utils/common-get-ssr-props';
 
 const ChangeUserPasswordPage: NextPage = () => {
-  const { authToken, isAdmin } = useAuthContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !isAdmin || !authToken) {
-    return <NotFoundPage />;
-  }
-
   return (
     <UserManagerLayout tabIndex={ManagerTabs.MANAGER}>
       <Container>
@@ -27,6 +18,8 @@ const ChangeUserPasswordPage: NextPage = () => {
 };
 
 export default ChangeUserPasswordPage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;
 
 const Container = styled.div({
   display: 'flex',

--- a/pages/auth/manage/user/[username]/delete-account.tsx
+++ b/pages/auth/manage/user/[username]/delete-account.tsx
@@ -4,19 +4,10 @@ import React from 'react';
 import { ManagerTabs } from '../../../../../src/stories/containers/users/users-manager/manager-tabs.enum';
 import UserManagerLayout from '../../../../../src/stories/containers/users/users-manager/user-manager-layout';
 import lightTheme from '../../../../../styles/theme/light';
-import { useAuthContext } from '../../../../../src/core/context/AuthContext';
-import { featureFlags } from '../../../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../../../src/config/endpoints';
-import NotFoundPage from '../../../../404';
 import DeleteAccount from '../../../../../src/stories/containers/users/delete-account/delete-account';
+import { getSSRPropsDefaultAuth } from '../../../../../src/core/utils/common-get-ssr-props';
 
 const DeleteUserAccountPage: NextPage = () => {
-  const { authToken, isAdmin } = useAuthContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !isAdmin || !authToken) {
-    return <NotFoundPage />;
-  }
-
   return (
     <UserManagerLayout tabIndex={ManagerTabs.MANAGER}>
       <Container>
@@ -27,6 +18,8 @@ const DeleteUserAccountPage: NextPage = () => {
 };
 
 export default DeleteUserAccountPage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;
 
 const Container = styled.div({
   display: 'flex',

--- a/pages/auth/manage/user/[username]/index.tsx
+++ b/pages/auth/manage/user/[username]/index.tsx
@@ -1,20 +1,11 @@
 import { NextPage } from 'next';
 import React from 'react';
-import { featureFlags } from '../../../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../../../src/config/endpoints';
-import { useAuthContext } from '../../../../../src/core/context/AuthContext';
+import { getSSRPropsDefaultAuth } from '../../../../../src/core/utils/common-get-ssr-props';
 import ManagedUserProfile from '../../../../../src/stories/containers/users/managed-user-profile/managed-user-profile';
 import { ManagerTabs } from '../../../../../src/stories/containers/users/users-manager/manager-tabs.enum';
 import UserManagerLayout from '../../../../../src/stories/containers/users/users-manager/user-manager-layout';
-import NotFoundPage from '../../../../404';
 
 const ManageUserProfilePage: NextPage = () => {
-  const { authToken, isAdmin } = useAuthContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !authToken || !isAdmin) {
-    return <NotFoundPage />;
-  }
-
   return (
     <UserManagerLayout tabIndex={ManagerTabs.MANAGER}>
       <ManagedUserProfile />
@@ -23,3 +14,5 @@ const ManageUserProfilePage: NextPage = () => {
 };
 
 export default ManageUserProfilePage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;

--- a/pages/auth/user-profile/index.tsx
+++ b/pages/auth/user-profile/index.tsx
@@ -1,19 +1,12 @@
 import { NextPage } from 'next';
 import React from 'react';
-import { featureFlags } from '../../../feature-flags/feature-flags';
-import { CURRENT_ENVIRONMENT } from '../../../src/config/endpoints';
-import { useAuthContext } from '../../../src/core/context/AuthContext';
+import { getSSRPropsDefaultAuth } from '../../../src/core/utils/common-get-ssr-props';
 import UserProfileContainer from '../../../src/stories/containers/users/user-profile/user-profile-container';
-import NotFoundPage from '../../404';
 
 const UserProfilePage: NextPage = () => {
-  const { authToken } = useAuthContext();
-
-  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH || !authToken) {
-    return <NotFoundPage />;
-  }
-
   return <UserProfileContainer />;
 };
 
 export default UserProfilePage;
+
+export const getServerSideProps = getSSRPropsDefaultAuth;

--- a/src/core/utils/common-get-ssr-props.ts
+++ b/src/core/utils/common-get-ssr-props.ts
@@ -1,0 +1,16 @@
+import { featureFlags } from '../../../feature-flags/feature-flags';
+import { CURRENT_ENVIRONMENT } from '../../config/endpoints';
+
+export const getSSRPropsDefaultAuth = async () => {
+  if (!featureFlags[CURRENT_ENVIRONMENT].FEATURE_AUTH) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      protected: true,
+    },
+  };
+};

--- a/src/stories/containers/users/users-manager/user-manager-layout.tsx
+++ b/src/stories/containers/users/users-manager/user-manager-layout.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from '@emotion/styled';
-import NotFoundPage from '../../../../../pages/404';
 import { useThemeContext } from '../../../../core/context/ThemeContext';
 import { Tabs } from '../../../components/tabs/tabs';
 import { useManagerAccountLayoutViewModel } from './manager-account-layout.mvvm';
@@ -13,28 +12,15 @@ export interface UserManagerLayoutProps {
 
 const UserManagerLayout: React.FC<UserManagerLayoutProps> = ({ children, tabIndex = ManagerTabs.PROFILE }) => {
   const { isLight } = useThemeContext();
-  const { tabItems, hasToken, authToken, isAdmin, FEATURE_AUTH } = useManagerAccountLayoutViewModel();
-
-  if (!FEATURE_AUTH || !authToken || !isAdmin) {
-    return <NotFoundPage />;
-  }
+  const { tabItems, hasToken, isAdmin } = useManagerAccountLayoutViewModel();
 
   if (!hasToken) {
-    return (
-      <div
-        style={{
-          width: '100vw',
-          height: '100vh',
-          display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'center',
-          alignItems: 'center',
-          fontSize: 30,
-        }}
-      >
-        Loading......
-      </div>
-    );
+    return <Message>Loading...</Message>;
+  }
+
+  if (!isAdmin) {
+    // TODO: Add a proper Forbidden page
+    return <Message>You do not have permissions to see this page</Message>;
   }
 
   return (
@@ -52,6 +38,18 @@ const UserManagerLayout: React.FC<UserManagerLayoutProps> = ({ children, tabInde
     </MainWrapper>
   );
 };
+
+export default UserManagerLayout;
+
+const Message = styled.div({
+  width: '100vw',
+  height: '100vh',
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'center',
+  alignItems: 'center',
+  fontSize: 30,
+});
 
 const MainWrapper = styled.div<{ isLight: boolean }>(({ isLight }) => ({
   display: 'flex',
@@ -99,5 +97,3 @@ const Container = styled.div({
     width: 1312,
   },
 });
-
-export default UserManagerLayout;


### PR DESCRIPTION
## Ticket
https://trello.com/c/36PbKQfa/189-feature-useraccounts-v1

## Actions
- add concept of `protected` routes to the project
- Redirect to login when the users try to enter to a protected route and they're no authenticated
- Show a forbidden message when the user are authenticated but they're not admins